### PR TITLE
Min iphone placeholder color

### DIFF
--- a/app/(user)/_layout.tsx
+++ b/app/(user)/_layout.tsx
@@ -1,9 +1,7 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import {Link, Redirect, Tabs} from 'expo-router';
-import {Pressable} from 'react-native';
+import {Redirect, Tabs} from 'expo-router';
 
 import Colors from '@/constants/Colors';
-import {useColorScheme} from '@/components/useColorScheme';
 import {useClientOnlyValue} from '@/components/useClientOnlyValue';
 import {useAuth} from '@/providers/AuthProvider';
 
@@ -16,7 +14,6 @@ function TabBarIcon(props: {
 }
 
 export default function TabLayout() {
-  const colorScheme = useColorScheme();
   const {session} = useAuth();
 
   // if use is not logged in, redirect to login page
@@ -27,7 +24,7 @@ export default function TabLayout() {
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+        tabBarActiveTintColor: Colors['light'].tint,
         // Disable the static render of the header on web
         // to prevent a hydration error in React Navigation v6.
         headerShown: useClientOnlyValue(false, true),

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,10 +1,8 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {
-  KeyboardAvoidingView,
   StatusBar,
   StyleSheet,
-  Platform,
 } from 'react-native';
 import {DarkTheme, DefaultTheme, ThemeProvider} from '@react-navigation/native';
 import {useFonts} from 'expo-font';
@@ -90,18 +88,13 @@ function RootLayoutNav() {
         barStyle="dark-content"
       />
       <SafeAreaProvider>
-        <KeyboardAvoidingView
-          style={styles.keyboardContainer}
-          enabled
-        >
-          <AuthProvider>
-            <Stack>
-              <Stack.Screen name="index" options={{headerShown: false}} />
-              <Stack.Screen name="(auth)" options={{headerShown: false}} />
-              <Stack.Screen name="(user)" options={{headerShown: false}} />
-            </Stack>
-          </AuthProvider>
-        </KeyboardAvoidingView>
+        <AuthProvider>
+          <Stack>
+            <Stack.Screen name="index" options={{headerShown: false}} />
+            <Stack.Screen name="(auth)" options={{headerShown: false}} />
+            <Stack.Screen name="(user)" options={{headerShown: false}} />
+          </Stack>
+        </AuthProvider>
       </SafeAreaProvider>
     </ThemeProvider>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,8 +1,6 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
-import {
-  StatusBar,
-} from 'react-native';
+import {StatusBar} from 'react-native';
 import {DarkTheme, DefaultTheme, ThemeProvider} from '@react-navigation/native';
 import {useFonts} from 'expo-font';
 import {Stack, useRouter} from 'expo-router';
@@ -51,7 +49,6 @@ export default function RootLayout() {
 }
 
 function RootLayoutNav() {
-  const colorScheme = useColorScheme();
   const router = useRouter();
 
   useEffect(() => {
@@ -80,7 +77,7 @@ function RootLayoutNav() {
   }, [router]);
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+    <ThemeProvider value={DefaultTheme}>
       <StatusBar
         backgroundColor="transparent"
         translucent={true}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,11 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
+import {
+  KeyboardAvoidingView,
+  StatusBar,
+  StyleSheet,
+  Platform,
+} from 'react-native';
 import {DarkTheme, DefaultTheme, ThemeProvider} from '@react-navigation/native';
 import {useFonts} from 'expo-font';
 import {Stack, useRouter} from 'expo-router';
@@ -77,13 +84,31 @@ function RootLayoutNav() {
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <AuthProvider>
-        <Stack>
-          <Stack.Screen name="index" options={{headerShown: false}} />
-          <Stack.Screen name="(auth)" options={{headerShown: false}} />
-          <Stack.Screen name="(user)" options={{headerShown: false}} />
-        </Stack>
-      </AuthProvider>
+      <StatusBar
+        backgroundColor="transparent"
+        translucent={true}
+        barStyle="dark-content"
+      />
+      <SafeAreaProvider>
+        <KeyboardAvoidingView
+          style={styles.keyboardContainer}
+          enabled
+        >
+          <AuthProvider>
+            <Stack>
+              <Stack.Screen name="index" options={{headerShown: false}} />
+              <Stack.Screen name="(auth)" options={{headerShown: false}} />
+              <Stack.Screen name="(user)" options={{headerShown: false}} />
+            </Stack>
+          </AuthProvider>
+        </KeyboardAvoidingView>
+      </SafeAreaProvider>
     </ThemeProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  keyboardContainer: {
+    flex: 1,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,8 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
-import {StatusBar, StyleSheet} from 'react-native';
+import {
+  StatusBar,
+} from 'react-native';
 import {DarkTheme, DefaultTheme, ThemeProvider} from '@react-navigation/native';
 import {useFonts} from 'expo-font';
 import {Stack, useRouter} from 'expo-router';

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,6 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
-import {
-  StatusBar,
-  StyleSheet,
-} from 'react-native';
+import {StatusBar, StyleSheet} from 'react-native';
 import {DarkTheme, DefaultTheme, ThemeProvider} from '@react-navigation/native';
 import {useFonts} from 'expo-font';
 import {Stack, useRouter} from 'expo-router';
@@ -99,9 +96,3 @@ function RootLayoutNav() {
     </ThemeProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  keyboardContainer: {
-    flex: 1,
-  },
-});

--- a/components/Divider.tsx
+++ b/components/Divider.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import {View, StyleSheet} from 'react-native';
+import {View, StyleSheet, DimensionValue} from 'react-native';
 
 interface Divider {
   inset: boolean;
-  width: number;
+  width: DimensionValue;
   color: string;
 }
 

--- a/components/Divider.tsx
+++ b/components/Divider.tsx
@@ -1,18 +1,26 @@
+// Divider.tsx
 import React from 'react';
 import {View, StyleSheet, DimensionValue} from 'react-native';
 
-interface Divider {
-  inset: boolean;
-  width: DimensionValue;
-  color: string;
+interface DividerProps {
+  inset?: boolean;
+  width?: DimensionValue | 'flex';
+  color?: string;
+  flex?: number;
 }
 
-const Divider: React.FC<Divider> = ({inset, width, color}) => {
-  const insetStyle = inset ? {marginHorizontal: 5} : {};
+const Divider: React.FC<DividerProps> = ({
+  inset = false,
+  width = 'flex',
+  color = 'black',
+  flex = 1,
+}) => {
+  const insetStyle = inset ? {marginHorizontal: 10} : {};
+  const flexStyle = width === 'flex' ? {flex} : {width};
 
   return (
     <View
-      style={[styles.divider, {width, backgroundColor: color}, insetStyle]}
+      style={[styles.divider, {backgroundColor: color}, insetStyle, flexStyle]}
     />
   );
 };

--- a/components/auth/AuthFooter.tsx
+++ b/components/auth/AuthFooter.tsx
@@ -14,7 +14,6 @@ const AuthFooter = () => {
 
 const styles = StyleSheet.create({
   footer: {
-    position: 'absolute',
     bottom: 10,
     left: 0,
     right: 0,

--- a/components/auth/AuthFooter.tsx
+++ b/components/auth/AuthFooter.tsx
@@ -6,21 +6,22 @@ import {View, StyleSheet, Text} from 'react-native';
 
 const AuthFooter = () => {
   return (
-    <View style={styles.footer}>
+    <View style={styles.footerContainer}>
       <Text style={styles.footerText}>Terms of Use | Privacy Policy</Text>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
-  footer: {
-    bottom: 10,
-    left: 0,
-    right: 0,
-    padding: 20,
+  footerContainer: {
+    flex: 1,
+    justifyContent: 'flex-end',
   },
   footerText: {
-    textAlign: 'center',
+    bottom: 25,
+    left: 0,
+    right: 0,
+    textAlign:'center',
     color: '#1177C7',
   },
 });

--- a/components/auth/AuthHeader.tsx
+++ b/components/auth/AuthHeader.tsx
@@ -33,10 +33,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
+    width: '100%',
   },
   backButtonContainer: {
     position: 'absolute',
     left: 20,
+    zIndex: 1,
   },
   logo: {
     width: 180,

--- a/components/auth/LoginScreen.tsx
+++ b/components/auth/LoginScreen.tsx
@@ -50,6 +50,7 @@ export default function LoginScreen() {
               onChangeText={(text: string) => setEmail(text)}
               value={email}
               placeholder="Email"
+              placeholderTextColor="rgba(50, 54, 62, 1)"
             />
           </View>
           <View>
@@ -59,6 +60,7 @@ export default function LoginScreen() {
               onChangeText={(text: string) => setPassword(text)}
               value={password}
               placeholder="Password"
+              placeholderTextColor="rgba(50, 54, 62, 1)"
             />
             <TouchableOpacity
               style={{

--- a/components/auth/LoginScreen.tsx
+++ b/components/auth/LoginScreen.tsx
@@ -6,7 +6,11 @@ import {
   Text,
   Dimensions,
   TouchableOpacity,
+  TouchableWithoutFeedback,
+  Keyboard,
   TextInput,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import LoginButton from '@/components/auth/buttons/LoginButtonFromLogin';
@@ -39,88 +43,94 @@ export default function LoginScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.view}>
-      <AuthHeader />
-      <View style={styles.container}>
-        <View style={styles.container2}>
-          <Text style={styles.textCreate}>Login</Text>
-          <View>
-            <TextInput
-              style={styles.textInput}
-              onChangeText={(text: string) => setEmail(text)}
-              value={email}
-              placeholder="Email"
-              placeholderTextColor="rgba(50, 54, 62, 1)"
-            />
-          </View>
-          <View>
-            <TextInput
-              style={styles.textInput}
-              secureTextEntry={!showPassword}
-              onChangeText={(text: string) => setPassword(text)}
-              value={password}
-              placeholder="Password"
-              placeholderTextColor="rgba(50, 54, 62, 1)"
-            />
-            <TouchableOpacity
-              style={{
-                position: 'absolute',
-                top: 15,
-                right: 10,
-                padding: 5,
-              }}
-              onPress={togglePasswordVisibility}
-            >
-              <Feather
-                name={showPassword ? 'eye' : 'eye-off'}
-                size={24}
-                color="black"
-              />
-            </TouchableOpacity>
-          </View>
-          <View style={styles.buttonContainer1}>
-            <LoginButton onPress={handleLogin} />
-          </View>
-          <Text style={styles.textMiddle}>Forgot Password?</Text>
-        </View>
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <SafeAreaView style={styles.view}>
+          <AuthHeader />
+          <View style={styles.container}>
+            <View style={styles.container2}>
+              <Text style={styles.textCreate}>Login</Text>
+              <View>
+                <TextInput
+                  style={styles.textInput}
+                  onChangeText={(text: string) => setEmail(text)}
+                  value={email}
+                  placeholder="Email"
+                  placeholderTextColor="rgba(50, 54, 62, 1)"
+                />
+              </View>
+              <View>
+                <TextInput
+                  style={styles.textInput}
+                  secureTextEntry={!showPassword}
+                  onChangeText={(text: string) => setPassword(text)}
+                  value={password}
+                  placeholder="Password"
+                  placeholderTextColor="rgba(50, 54, 62, 1)"
+                />
+                <TouchableOpacity
+                  style={{
+                    position: 'absolute',
+                    top: 15,
+                    right: 10,
+                    padding: 5,
+                  }}
+                  onPress={togglePasswordVisibility}
+                >
+                  <Feather
+                    name={showPassword ? 'eye' : 'eye-off'}
+                    size={24}
+                    color="black"
+                  />
+                </TouchableOpacity>
+              </View>
+              <View style={styles.buttonContainer1}>
+                <LoginButton onPress={handleLogin} />
+              </View>
+              <Text style={styles.textMiddle}>Forgot Password?</Text>
+            </View>
 
-        <View style={styles.container3}>
-          <View style={styles.buttonContainer2}>
-            <Divider inset={true} width={100} color="black" />
-            <Text style={styles.textSmall}>or sign in with</Text>
-            <Divider inset={true} width={100} color="black" />
-          </View>
-          <View style={styles.buttonContainer3}>
-            <View style={styles.logoGContainer}>
-              <Image
-                style={[styles.logo, styles.logoG]}
-                resizeMode="contain"
-                source={require('../../assets/images/User/auth-google-logo.png')}
-              />
+            <View style={styles.container3}>
+              <View style={styles.buttonContainer2}>
+                <Divider inset flex={1} />
+                <Text style={styles.textSmall}>or sign in with</Text>
+                <Divider inset flex={1} />
+              </View>
+              <View style={styles.buttonContainer3}>
+                <View style={styles.logoGContainer}>
+                  <Image
+                    style={[styles.logo, styles.logoG]}
+                    resizeMode="contain"
+                    source={require('../../assets/images/User/auth-google-logo.png')}
+                  />
+                </View>
+                <Image
+                  style={styles.logo}
+                  resizeMode="contain"
+                  source={require('../../assets/images/User/auth-facebook-logo.jpg')}
+                />
+                <View style={styles.logoAppleContainer}>
+                  <Image
+                    style={[styles.logo, styles.logoApple]}
+                    resizeMode="contain"
+                    source={require('../../assets/images/User/auth-apple-logo.png')}
+                  />
+                </View>
+              </View>
+              <Text style={[styles.textSmall, styles.greyText]}>
+                Don’t have an account?{' '}
+                <Link href="/signup">
+                  <Text style={styles.linkText}>Sign Up</Text>
+                </Link>
+              </Text>
+              <AuthFooter />
             </View>
-            <Image
-              style={styles.logo}
-              resizeMode="contain"
-              source={require('../../assets/images/User/auth-facebook-logo.jpg')}
-            />
-            <View style={styles.logoAppleContainer}>
-              <Image
-                style={[styles.logo, styles.logoApple]}
-                resizeMode="contain"
-                source={require('../../assets/images/User/auth-apple-logo.png')}
-              />
-            </View>
           </View>
-          <Text style={[styles.textSmall, styles.greyText]}>
-            Don’t have an account?{' '}
-            <Link href="/signup">
-              <Text style={styles.linkText}>Sign Up</Text>
-            </Link>
-          </Text>
-          <AuthFooter />
-        </View>
-      </View>
-    </SafeAreaView>
+        </SafeAreaView>
+      </TouchableWithoutFeedback>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/components/auth/SignupScreen.tsx
+++ b/components/auth/SignupScreen.tsx
@@ -4,7 +4,6 @@ import {
   StyleSheet,
   View,
   Text,
-  Dimensions,
   TouchableOpacity,
   TextInput,
   KeyboardAvoidingView,
@@ -21,11 +20,6 @@ import Divider from '../Divider';
 import AuthHeader from './AuthHeader';
 import AuthFooter from './AuthFooter';
 import {signupWithEmail} from '@/lib/Auth';
-
-const {width, height} = Dimensions.get('window');
-
-const window_width = width;
-const window_height = height;
 
 export default function LoginScreen() {
   const [email, setEmail] = useState('');
@@ -53,14 +47,14 @@ export default function LoginScreen() {
 
   return (
     <KeyboardAvoidingView
-      behavior={Platform.OS == 'ios' ? 'padding' : 'height'}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       style={{flex: 1}}
       enabled
     >
       <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-        <SafeAreaView style={[styles.view]}>
+        <SafeAreaView style={styles.view}>
+          <AuthHeader />
           <View style={styles.container}>
-            <AuthHeader />
             <View style={styles.signupFieldsContainer}>
               <Text style={styles.textCreate}>Create an Account</Text>
               <View>
@@ -130,9 +124,9 @@ export default function LoginScreen() {
               />
 
               <View style={[styles.dividerContainer]}>
-                <Divider inset={true} width={100} color="black" />
+                <Divider inset flex={1} />
                 <Text style={[styles.textSmall]}>or sign up with</Text>
-                <Divider inset={true} width={100} color="black" />
+                <Divider inset flex={1} />
               </View>
 
               <View style={[styles.otherSignupButtonsContainer]}>

--- a/components/auth/SignupScreen.tsx
+++ b/components/auth/SignupScreen.tsx
@@ -123,9 +123,9 @@ export default function LoginScreen() {
                 style={styles.signupButton}
               />
 
-              <View style={[styles.dividerContainer]}>
+              <View style={styles.dividerContainer}>
                 <Divider inset flex={1} />
-                <Text style={[styles.textSmall]}>or sign up with</Text>
+                <Text style={styles.textSmall}>or sign up with</Text>
                 <Divider inset flex={1} />
               </View>
 
@@ -195,7 +195,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-around',
     alignItems: 'center',
     width: '100%',
-    gap: 10,
   },
   divider: {
     width: '100%',

--- a/components/auth/SignupScreen.tsx
+++ b/components/auth/SignupScreen.tsx
@@ -113,14 +113,14 @@ export default function LoginScreen() {
         </View>
 
         <View style={[styles.signupButtonsContainer]}>
-          <View style={[styles.buttonContainer1]}>
-            <SignupButton onPress={handleSignup} />
-          </View>
-          <View style={[styles.buttonContainer2]}>
+          <SignupButton onPress={handleSignup} style={styles.signupButton} />
+
+          <View style={[styles.dividerContainer]}>
             <Divider inset={true} width={100} color="black" />
             <Text style={[styles.textSmall]}>or sign up with</Text>
             <Divider inset={true} width={100} color="black" />
           </View>
+
           <View style={[styles.buttonContainer3]}>
             <View style={styles.logoGContainer}>
               <Image
@@ -148,8 +148,8 @@ export default function LoginScreen() {
               <Text style={styles.linkText}>Log in</Text>
             </Link>
           </Text>
-          <AuthFooter />
         </View>
+        <AuthFooter />
       </View>
     </SafeAreaView>
   );
@@ -160,6 +160,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: 'white',
     alignItems: 'center',
+    justifyContent: 'center',
   },
   container: {
     flex: 1,
@@ -167,10 +168,35 @@ const styles = StyleSheet.create({
   },
   signupFieldsContainer: {
     marginBottom: 20,
+    width: '100%',
   },
   signupButtonsContainer: {
     alignItems: 'center',
     alignSelf: 'center',
+    width: '100%',
+  },
+  signupButton: {
+    width: '100%',
+  },
+  dividerContainer: {
+    marginTop: 40,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+    width: '100%',
+    gap: 10,
+  },
+  divider: {
+    width: '100%',
+  },
+  buttonContainer3: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+    width: '100%',
+    marginTop: 20,
+    marginBottom: 40,
+    paddingHorizontal: '10%',
   },
   checkbox: {
     marginRight: 0,
@@ -217,30 +243,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     marginTop: 13,
-  },
-  buttonContainer1: {
-    flexDirection: 'column',
-    justifyContent: 'space-around',
-    alignItems: 'center',
-    width: '100%',
-    gap: 10,
-  },
-  buttonContainer2: {
-    marginTop: 40,
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    alignItems: 'center',
-    width: '100%',
-    gap: 10,
-  },
-  buttonContainer3: {
-    marginTop: 20,
-    marginBottom: 40,
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    alignItems: 'center',
-    width: '60%',
-    gap: 10,
   },
   logo: {
     width: 35,

--- a/components/auth/SignupScreen.tsx
+++ b/components/auth/SignupScreen.tsx
@@ -148,8 +148,8 @@ export default function LoginScreen() {
               <Text style={styles.linkText}>Log in</Text>
             </Link>
           </Text>
+          <AuthFooter />
         </View>
-        <AuthFooter />
       </View>
     </SafeAreaView>
   );

--- a/components/auth/SignupScreen.tsx
+++ b/components/auth/SignupScreen.tsx
@@ -60,6 +60,7 @@ export default function LoginScreen() {
                 onChangeText={(text: string) => setEmail(text)}
                 value={email}
                 placeholder="Email"
+                placeholderTextColor="rgba(50, 54, 62, 1)"
               />
             </View>
             <View>
@@ -69,6 +70,7 @@ export default function LoginScreen() {
                 onChangeText={(text: string) => setPassword(text)}
                 value={password}
                 placeholder="Password"
+                placeholderTextColor="rgba(50, 54, 62, 1)"
               />
               <TouchableOpacity
                 style={{

--- a/components/auth/SignupScreen.tsx
+++ b/components/auth/SignupScreen.tsx
@@ -7,6 +7,10 @@ import {
   Dimensions,
   TouchableOpacity,
   TextInput,
+  KeyboardAvoidingView,
+  Platform,
+  Keyboard,
+  TouchableWithoutFeedback,
 } from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {CheckBox} from '@rneui/themed';
@@ -48,110 +52,123 @@ export default function LoginScreen() {
   };
 
   return (
-    <SafeAreaView style={[styles.view]}>
-      <View style={styles.container}>
-        <AuthHeader />
-        <View style={styles.signupFieldsContainer}>
-          <Text style={styles.textCreate}>Create an Account</Text>
-          <View>
-            <View>
-              <TextInput
-                style={styles.textInput}
-                onChangeText={(text: string) => setEmail(text)}
-                value={email}
-                placeholder="Email"
-                placeholderTextColor="rgba(50, 54, 62, 1)"
-              />
-            </View>
-            <View>
-              <TextInput
-                style={styles.textInput}
-                secureTextEntry={!showPassword}
-                onChangeText={(text: string) => setPassword(text)}
-                value={password}
-                placeholder="Password"
-                placeholderTextColor="rgba(50, 54, 62, 1)"
-              />
-              <TouchableOpacity
-                style={{
-                  position: 'absolute',
-                  top: 15,
-                  right: 10,
-                  padding: 5,
-                }}
-                onPress={togglePasswordVisibility}
-              >
-                <Feather
-                  name={showPassword ? 'eye' : 'eye-off'}
-                  size={24}
-                  color="black"
-                />
-              </TouchableOpacity>
+    <KeyboardAvoidingView
+      behavior={Platform.OS == 'ios' ? 'padding' : 'height'}
+      style={{flex: 1}}
+      enabled
+    >
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <SafeAreaView style={[styles.view]}>
+          <View style={styles.container}>
+            <AuthHeader />
+            <View style={styles.signupFieldsContainer}>
+              <Text style={styles.textCreate}>Create an Account</Text>
+              <View>
+                <View>
+                  <TextInput
+                    style={styles.textInput}
+                    onChangeText={(text: string) => setEmail(text)}
+                    value={email}
+                    placeholder="Email"
+                    placeholderTextColor="rgba(50, 54, 62, 1)"
+                  />
+                </View>
+                <View>
+                  <TextInput
+                    style={styles.textInput}
+                    secureTextEntry={!showPassword}
+                    onChangeText={(text: string) => setPassword(text)}
+                    value={password}
+                    placeholder="Password"
+                    placeholderTextColor="rgba(50, 54, 62, 1)"
+                  />
+                  <TouchableOpacity
+                    style={{
+                      position: 'absolute',
+                      top: 15,
+                      right: 10,
+                      padding: 5,
+                    }}
+                    onPress={togglePasswordVisibility}
+                  >
+                    <Feather
+                      name={showPassword ? 'eye' : 'eye-off'}
+                      size={24}
+                      color="black"
+                    />
+                  </TouchableOpacity>
+                </View>
+
+                <Text style={[styles.textSmall, styles.textGrey]}>
+                  Password must be at least 8 characters and contain a letter
+                  and a number.
+                </Text>
+                <View style={styles.containercheckbox}>
+                  <CheckBox
+                    checked={isChecked}
+                    onPress={handleCheckboxChange}
+                    style={styles.checkbox}
+                    containerStyle={{marginRight: 0, paddingRight: 5}}
+                  />
+                  <Text style={[styles.textSmall, styles.inlineText]}>
+                    <Text style={[styles.textGrey]}>
+                      By clicking Sign Up, you acknowledge that you have read
+                      the
+                    </Text>
+                    <Text style={[styles.textBlue]}> Privacy Policy</Text>
+                    <Text style={[styles.textGrey]}> and agree to the</Text>
+                    <Text style={[styles.textBlue]}> Terms of Service</Text>
+                  </Text>
+                </View>
+              </View>
             </View>
 
-            <Text style={[styles.textSmall, styles.textGrey]}>
-              Password must be at least 8 characters and contain a letter and a
-              number.
-            </Text>
-            <View style={styles.containercheckbox}>
-              <CheckBox
-                checked={isChecked}
-                onPress={handleCheckboxChange}
-                style={styles.checkbox}
-                containerStyle={{marginRight: 0, paddingRight: 5}}
+            <View style={[styles.signupButtonsContainer]}>
+              <SignupButton
+                onPress={handleSignup}
+                style={styles.signupButton}
               />
-              <Text style={[styles.textSmall, styles.inlineText]}>
-                <Text style={[styles.textGrey]}>
-                  By clicking Sign Up, you acknowledge that you have read the
-                </Text>
-                <Text style={[styles.textBlue]}> Privacy Policy</Text>
-                <Text style={[styles.textGrey]}> and agree to the</Text>
-                <Text style={[styles.textBlue]}> Terms of Service</Text>
+
+              <View style={[styles.dividerContainer]}>
+                <Divider inset={true} width={100} color="black" />
+                <Text style={[styles.textSmall]}>or sign up with</Text>
+                <Divider inset={true} width={100} color="black" />
+              </View>
+
+              <View style={[styles.otherSignupButtonsContainer]}>
+                <View style={styles.logoGContainer}>
+                  <Image
+                    style={[styles.logo, styles.logoG]}
+                    resizeMode="contain"
+                    source={require('../../assets/images/User/auth-google-logo.png')}
+                  />
+                </View>
+                <Image
+                  style={[styles.logo]}
+                  resizeMode="contain"
+                  source={require('../../assets/images/User/auth-facebook-logo.jpg')}
+                />
+                <View style={styles.logoAppleContainer}>
+                  <Image
+                    style={[styles.logo, styles.logoApple]}
+                    resizeMode="contain"
+                    source={require('../../assets/images/User/auth-apple-logo.png')}
+                  />
+                </View>
+              </View>
+
+              <Text style={[styles.textSmall, styles.textGrey]}>
+                Already have an account?{' '}
+                <Link href={'/login'} asChild>
+                  <Text style={styles.linkText}>Log in</Text>
+                </Link>
               </Text>
             </View>
+            <AuthFooter />
           </View>
-        </View>
-
-        <View style={[styles.signupButtonsContainer]}>
-          <SignupButton onPress={handleSignup} style={styles.signupButton} />
-
-          <View style={[styles.dividerContainer]}>
-            <Divider inset={true} width={100} color="black" />
-            <Text style={[styles.textSmall]}>or sign up with</Text>
-            <Divider inset={true} width={100} color="black" />
-          </View>
-
-          <View style={[styles.buttonContainer3]}>
-            <View style={styles.logoGContainer}>
-              <Image
-                style={[styles.logo, styles.logoG]}
-                resizeMode="contain"
-                source={require('../../assets/images/User/auth-google-logo.png')}
-              />
-            </View>
-            <Image
-              style={[styles.logo]}
-              resizeMode="contain"
-              source={require('../../assets/images/User/auth-facebook-logo.jpg')}
-            />
-            <View style={styles.logoAppleContainer}>
-              <Image
-                style={[styles.logo, styles.logoApple]}
-                resizeMode="contain"
-                source={require('../../assets/images/User/auth-apple-logo.png')}
-              />
-            </View>
-          </View>
-          <Text style={[styles.textSmall, styles.textGrey]}>
-            Already have an account?{' '}
-            <Link href={'/login'} asChild>
-              <Text style={styles.linkText}>Log in</Text>
-            </Link>
-          </Text>
-          <AuthFooter />
-        </View>
-      </View>
-    </SafeAreaView>
+        </SafeAreaView>
+      </TouchableWithoutFeedback>
+    </KeyboardAvoidingView>
   );
 }
 
@@ -189,7 +206,7 @@ const styles = StyleSheet.create({
   divider: {
     width: '100%',
   },
-  buttonContainer3: {
+  otherSignupButtonsContainer: {
     flexDirection: 'row',
     justifyContent: 'space-around',
     alignItems: 'center',

--- a/components/auth/SignupScreen.tsx
+++ b/components/auth/SignupScreen.tsx
@@ -49,9 +49,9 @@ export default function LoginScreen() {
 
   return (
     <SafeAreaView style={[styles.view]}>
-      <AuthHeader />
       <View style={styles.container}>
-        <View style={styles.container2}>
+        <AuthHeader />
+        <View style={styles.signupFieldsContainer}>
           <Text style={styles.textCreate}>Create an Account</Text>
           <View>
             <View>
@@ -112,7 +112,7 @@ export default function LoginScreen() {
           </View>
         </View>
 
-        <View style={[styles.container3]}>
+        <View style={[styles.signupButtonsContainer]}>
           <View style={[styles.buttonContainer1]}>
             <SignupButton onPress={handleSignup} />
           </View>
@@ -157,21 +157,20 @@ export default function LoginScreen() {
 
 const styles = StyleSheet.create({
   view: {
-    display: 'flex',
+    flex: 1,
     backgroundColor: 'white',
-    minWidth: window_width,
-    minHeight: window_height,
+    alignItems: 'center',
   },
   container: {
-    flexDirection: 'column',
     flex: 1,
-    marginTop: 15,
+    width: '85%',
   },
-  container1: {
-    flex: 1,
+  signupFieldsContainer: {
+    marginBottom: 20,
+  },
+  signupButtonsContainer: {
     alignItems: 'center',
-    justifyContent: 'center',
-    flexDirection: 'row',
+    alignSelf: 'center',
   },
   checkbox: {
     marginRight: 0,
@@ -218,19 +217,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     marginTop: 13,
-  },
-  container2: {
-    flex: 6,
-    flexDirection: 'column',
-    alignSelf: 'center',
-    width: '80%',
-  },
-  container3: {
-    flex: 6.8,
-    flexDirection: 'column',
-    alignItems: 'center',
-    alignSelf: 'center',
-    width: '80%',
   },
   buttonContainer1: {
     flexDirection: 'column',

--- a/components/auth/SignupScreen.tsx
+++ b/components/auth/SignupScreen.tsx
@@ -203,10 +203,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-around',
     alignItems: 'center',
-    width: '100%',
+    width: '60%',
     marginTop: 20,
     marginBottom: 40,
-    paddingHorizontal: '10%',
   },
   checkbox: {
     marginRight: 0,

--- a/components/auth/buttons/SignupButtonFromSignup.tsx
+++ b/components/auth/buttons/SignupButtonFromSignup.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import {Text, TouchableOpacity, StyleSheet} from 'react-native';
-
+import { TouchableOpacity, Text, StyleSheet, TouchableOpacityProps, StyleProp, ViewStyle } from 'react-native';
 interface SignupButtonProps {
   onPress: () => void;
+  style?: StyleProp<ViewStyle>;
 }
 
-const SignupButton: React.FC<SignupButtonProps> = ({onPress}) => {
+const SignupButton: React.FC<SignupButtonProps> = ({onPress, style}) => {
   return (
-    <TouchableOpacity style={styles.button} onPress={onPress}>
+    <TouchableOpacity style={[styles.button, style]} onPress={onPress}>
       <Text style={styles.text}>Sign Up</Text>
     </TouchableOpacity>
   );
@@ -15,8 +15,8 @@ const SignupButton: React.FC<SignupButtonProps> = ({onPress}) => {
 
 const styles = StyleSheet.create({
   button: {
-    width: 324,
-    height: 56,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
     borderRadius: 28,
     backgroundColor: 'black',
     justifyContent: 'center',

--- a/components/useColorScheme.ts
+++ b/components/useColorScheme.ts
@@ -1,1 +1,1 @@
-export { useColorScheme } from 'react-native';
+export {useColorScheme} from 'react-native';


### PR DESCRIPTION
## Describe your changes
- Add color to placeholder text so both iOS and Android share the same color
- Restyle the signup screen so that the sign up button have more space between itself and the 'term of service':
  - Add `SafeAreaProvider` so that `SafeAreaView` can take effect [ref](https://docs.expo.dev/develop/user-interface/safe-areas/)
  - Rename and restyle some container and components

## Issue ticket number and link
#57 #60 

## Screenshots / Video
Add your media here...

## Checklist
- [x] I have performed a self-review of my code
- [x] I have used `npx expo-doctor` to review any dependency issues.
- [x] I have pulled and merged any recent changes from the main branch (no merge conflicts)
- [x] I have tested thoroughly any edge cases that might break the application
- [x] I have deleted any console.log statements and useless comments
